### PR TITLE
Fixed a minor bug in tile_all

### DIFF
--- a/rtile.rb
+++ b/rtile.rb
@@ -392,7 +392,7 @@ def tile_all(settings, windows, monitors, current_workspace)
 
 	monitors.each do |monitor|
 		monitor_windows = get_sorted_monitor_windows(settings, monitor_hash[monitor.name], monitor, current_workspace)
-		break if monitor_windows.empty?
+		next if monitor_windows.empty?
 		
 		column_sizes = nil
 		unless settings.column_configs.empty?


### PR DESCRIPTION
First of all, thanks a lot for this great script! It was exactly what I was looking for, and I love it!

The fix I want to push:
When having several monitors connected, and one of them has no windows, the loop for "tile_all" had stopped when got to the monitor with no windows.
I've changed the loop to skip it, in order to tile the windows on the other monitors as well.